### PR TITLE
feat: REM-17592 new tenant updated messages and new tenant fields

### DIFF
--- a/letting_context.md
+++ b/letting_context.md
@@ -8,10 +8,11 @@
 | [Letting.Tenancy.Created](#lettingtenancycreated)                                                   | :white_check_mark: | :x:                | A tenancy has been created; does not reliably signal a tenant move in. (1)     |
 | [Letting.Tenancy.Deleted](#lettingtenancydeleted)                                                   | :white_check_mark: | :x:                | A tenancy has been deleted; this means that the tenancy never became effective |
 | [Letting.Tenancy.MoveInConfirmed](#lettingtenancymoveinconfirmed)                                   | :x:                | :white_check_mark: | Confirms a tenant will move or has moved into a unit. (2)                      |
-| [Letting.Tenancy.MoveOutConfirmed](#lettingtenancymoveoutconfirmed)                                 | :x:                | :white_check_mark: | Confirms a tenant will move out or has moved out of a unit. (3)                |
 | [Letting.Tenancy.TenancyAgreementReferenceChanged](#lettingtenancytenancyagreementreferencechanged) | :white_check_mark: | :x:                | The reference of a tenancy agreement has changed                               |
 | [Letting.Tenancy.Updated](#lettingtenancyupdated)                                                   | :white_check_mark: | :x:                | Start and / or end date of a tenancy have been changed                         |
 | [Letting.TenancyAgreement.Activate](#lettingtenancyagreementactivate)                               | :white_check_mark: | :x:                | A tenancy agreement should be activated in GARAIO REM                          |
+| [Letting.Tenant.Merged](#lettingtenantmerged)                                                       | :white_check_mark: | :x:                | Notification when tenant has been merged into another record (all known new Tenant info is sent) |
+| [Letting.Tenant.Updated](#lettingtenantupdated)                                                     | :white_check_mark: | :x:                | Notification when tenant information has been updated/changed                  |
 | [Letting.TenancyAgreement.Create](#lettingtenancyagreementcreate)                                   | :white_check_mark: | :x:                | A tenancy agreement should be created in GARAIO REM                            |
 | [Letting.TenancyAgreement.Created](#lettingtenancyagreementcreated)                                 | :white_check_mark: | :x:                | The tenancy agreement has been activated.                                      |
 | [Letting.TenancyAgreement.Deactivated](#lettingtenancyagreementdeactivated)                         | :white_check_mark: | :x:                | The tenancy agreement has been deactivated.                                    |
@@ -25,7 +26,6 @@
 | [Letting.TenancyAgreement.Updated](#lettingtenancyagreementupdated)                                 | :white_check_mark: | :x:                | The activated tenancy agreement has some changes.                              |
 | [Letting.TenancyAgreementDetails.Update](#lettingtenancyagreementdetailsupdate)                     | :white_check_mark: | :x:                | Updates some details of a tenancy agreement.                                   |
 | [Letting.TenancyAgreementSecurityDepot.Update](#lettingtenancyagreementsecuritydepotupdate)         | :white_check_mark: | :x:                | Updates the reservation status of a unit.                                      |
-| [Letting.Tenant.Updated](#lettingtenantupdated)                                                     | :white_check_mark: | :x:                | Notification when tenant information has been updated/changed                  |
 
 Notes
 
@@ -51,9 +51,11 @@ stateDiagram-v2
     Deactivated --> [*]
 ```
 
-### Letting.Tenancy.Created
+**NOTE:** New tenant fields have been added to be consistent with the GraphQL API. Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
 
-NOTE: We have discoved minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values Legal and Physical persons.  At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
+NOTE: We have discovered minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values for Legal and Physical persons. At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
+
+### Letting.Tenancy.Created
 
 | Field                                           | Type              | Content / Remarks                                                                           |
 | ----------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------- |
@@ -69,8 +71,9 @@ NOTE: We have discoved minor differences in the logic for sending the _preferred
 | &nbsp;&nbsp;&nbsp;&nbsp;surname                 | `string`          |                                                                                             |
 | &nbsp;&nbsp;&nbsp;&nbsp;languageCode            | `string`          | de, fr, it or en; **must be lower case**                                                    |
 | &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode         | `string`          | ISO country code (ISO 3166-1 alpha-2), eg 'CH'                                              |
-| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber             | `string`          | might be null                                                                               |
-| &nbsp;&nbsp;&nbsp;&nbsp;email                   | `string`          | might be null                                                                               |
+| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber             | `string`          | preferred number (based on person type) - might be null                                     |
+| &nbsp;&nbsp;&nbsp;&nbsp;email                   | `string`          | preferred email (based on person type) - might be null                                      |
+| new fields                                      |                   | Introduced in v1.21 (Q1 2024)                                                               |
 | &nbsp;&nbsp;&nbsp;&nbsp;fullName                | `string`          | built from the individual name parts, respecting the type of tenant (corporate or physical) |
 | &nbsp;&nbsp;&nbsp;&nbsp;type                    | `string`          | LEGAL (a company) or PHYSICAL (Physical person)                                             |
 | &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth             | `string`          | ISO 8601 encoded date, eg '2019-05-30'                                                      |
@@ -1052,6 +1055,89 @@ Additional `data` fields:
 | Field       | Type     | Content / Remarks               |
 | ----------- | -------- | ------------------------------- |
 | `reference` | `string` | The tenancy agreement reference |
+
+
+### Letting.Tenant.Merged
+
+In this case we send the entire new (merged) tenant data set.
+
+It is important to note that the 'tenantReference' refers to the old tenant record and the 'tenant.reference' refers to the new tenant record.
+
+_(Currently we only record a few basic fields of the old record before it is merged so a true diff is not possible)._
+
+| Field                                      | Type     | Content / Remarks                                         |
+| ------------------------------------------ | -------- | --------------------------------------------------------- |
+| eventType                                  | `string` | Letting.Tenant.Merged                                    |
+| data                                       | `hash`   |                                                           |
+| &nbsp;&nbsp;tenancyAgreementReference      | `string` | unique tenancy agreement identifier, eg '1234.01.0001.01' |
+| &nbsp;&nbsp;unitReference                  | `string` | unique unit identifier, eg '234.01.0001'                  |
+| &nbsp;&nbsp;tenantReference                | `string` | unique unit identifier, eg '987654' of prior tenant reference |
+| &nbsp;&nbsp;tenant                         | `hash`   |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;reference          | `string` | uniquely identifies the NEW tenant reference              |
+| &nbsp;&nbsp;&nbsp;&nbsp;firstName          | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;surname            | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;languageCode       | `string` | de, fr, it or en; **must be lower case** (ISO 639-1)      |
+| &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode    | `string` | ISO country code, eg 'CH' (ISO 3166-1 alpha-2)            |
+| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber        | `string` | preferred number (based on person type) - might be null   |
+| &nbsp;&nbsp;&nbsp;&nbsp;email              | `string` | preferred email (based on person type) - might be null    |
+| &nbsp;&nbsp;&nbsp;&nbsp;fullName           | `string` | built from the individual name parts, respecting the type of tenant (corporate or physical) |
+| &nbsp;&nbsp;&nbsp;&nbsp;type               | `string` | LEGAL (a company) or PHYSICAL (Physical person)           |
+| &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth        | `string` | ISO 8601 encoded date, eg '2019-05-30'                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;allphoneNumbers    | `array of hashes` | a list of all available email addresses and type |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;phoneNumber  | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL, MOBILE or OTHER            |
+| &nbsp;&nbsp;&nbsp;&nbsp;allEmails          | `array of hashes` | a list of all available email addresses and type |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;emailAddress | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL or OTHER                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;postalAddress      | `hash`   | current address fields conformant to the eCH-0010 specs   |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;addressLine1 | `string` | See eCH-0010 specs                                        |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;countryCode  | `string` | ISO 3166-1 alpha-2 country code, eg CH                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;city         | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode      | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string` | See eCH-0010 specs                                   |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street       | `string` | Street name including number where appropriate            |
+
+#### Example
+
+```json
+{"eventType":"Letting.Tenant.Merged",
+  "data":{
+    "tenancyAgreementReference":"10001.786.29.01",
+    "unitReference":"10001.786.29",
+    "tenantReference":"987654",
+    "tenant":{
+      "reference":"100004",
+      "firstName":"Haupt",
+      "surname":"Mieter",
+      "languageCode":"de",
+      "nationalityCode":"AT",
+      "phoneNumber":"+41 31 331 21 11",
+      "email":"name@home-mail.xy",
+      "fullName":"Haupt Mieter",
+      "type":"PHYSICAL",
+      "dateOfBirth":"1980-01-01",
+      "allphoneNumbers":[
+        {"phoneNumber":"+41 31 331 21 11","type":"PRIVATE"},
+        {"phoneNumber":"+41 31 331 21 12","type":"PROFESSIONAL"},
+        {"phoneNumber":"+41 31 331 21 13","type":"MOBILE"},
+        {"phoneNumber":"+41 31 331 21 14","type":"OTHER"}
+      ],
+      "allEmails":[
+        {"emailAddress":"name@home-mail.xy","type":"PRIVATE"},
+        {"emailAddress":"username@work-mail.yz","type":"PROFESSIONAL"}
+      ],
+      "postalAddress":{
+        "addressLine1":"Haupt Mieter",
+        "countryCode":"CH",
+        "city":"Bern",
+        "zipCode":"3000",
+        "postOfficeBoxText":"Postfach 1234",
+        "street":"Hauptstrasse 1"
+      }
+    }
+  }
+}
+```
 
 ### Letting.Tenant.Updated
 

--- a/letting_context.md
+++ b/letting_context.md
@@ -54,10 +54,11 @@ stateDiagram-v2
 
 ### Letting.Tenancy.Created
 
-**NOTE:** New tenant fields have been added to be consistent with the GraphQL API, these include (fullName, type, dateOfBirth, type, allphoneNumbers, allEmails & postalAddress)
-Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
+**NOTES**: 
 
-NOTE: We have discovered minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values for Legal and Physical persons. At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
+- We have discovered minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values for Legal and Physical persons. At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
+- New tenant fields have been added to be consistent with the GraphQL API, these include (fullName, type, dateOfBirth, type, allphoneNumbers, allEmails & postalAddress)
+Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
 
 | Field                                           | Type              | Content / Remarks                                                                           |
 | ----------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------- |
@@ -1066,37 +1067,37 @@ It is important to note that the 'tenantReference' refers to the old tenant reco
 
 _(Currently we only record a few basic fields of the old record before it is merged so a true diff is not possible)._
 
-| Field                                      | Type     | Content / Remarks                                         |
-| ------------------------------------------ | -------- | --------------------------------------------------------- |
-| eventType                                  | `string` | Letting.Tenant.Merged                                    |
-| data                                       | `hash`   |                                                           |
-| &nbsp;&nbsp;tenancyAgreementReference      | `string` | unique tenancy agreement identifier, eg '1234.01.0001.01' |
-| &nbsp;&nbsp;unitReference                  | `string` | unique unit identifier, eg '234.01.0001'                  |
-| &nbsp;&nbsp;tenantReference                | `string` | unique unit identifier, eg '987654' of prior tenant reference |
-| &nbsp;&nbsp;tenant                         | `hash`   |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;reference          | `string` | uniquely identifies the NEW tenant reference              |
-| &nbsp;&nbsp;&nbsp;&nbsp;firstName          | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;surname            | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;languageCode       | `string` | de, fr, it or en; **must be lower case** (ISO 639-1)      |
-| &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode    | `string` | ISO country code, eg 'CH' (ISO 3166-1 alpha-2)            |
-| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber        | `string` | preferred number (based on person type) - might be null   |
-| &nbsp;&nbsp;&nbsp;&nbsp;email              | `string` | preferred email (based on person type) - might be null    |
-| &nbsp;&nbsp;&nbsp;&nbsp;fullName           | `string` | built from the individual name parts, respecting the type of tenant (corporate or physical) |
-| &nbsp;&nbsp;&nbsp;&nbsp;type               | `string` | LEGAL (a company) or PHYSICAL (Physical person)           |
-| &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth        | `string` | ISO 8601 encoded date, eg '2019-05-30'                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;allphoneNumbers    | `array of hashes` | a list of all available email addresses and type |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;phoneNumber  | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL, MOBILE or OTHER            |
-| &nbsp;&nbsp;&nbsp;&nbsp;allEmails          | `array of hashes` | a list of all available email addresses and type |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;emailAddress | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL or OTHER                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;postalAddress      | `hash`   | current address fields conformant to the eCH-0010 specs   |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;addressLine1 | `string` | See eCH-0010 specs                                        |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;countryCode  | `string` | ISO 3166-1 alpha-2 country code, eg CH                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;city         | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode      | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string` | See eCH-0010 specs                                   |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street       | `string` | Street name including number where appropriate            |
+| Field                                           | Type              | Content / Remarks                                                                           |
+| ----------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------- |
+| eventType                                       | `string`          | Letting.Tenant.Merged                                                                       |
+| data                                            | `hash`            |                                                                                             |
+| &nbsp;&nbsp;tenancyAgreementReference           | `string`          | unique tenancy agreement identifier, eg '1234.01.0001.01'                                   |
+| &nbsp;&nbsp;unitReference                       | `string`          | unique unit identifier, eg '234.01.0001'                                                    |
+| &nbsp;&nbsp;tenantReference                     | `string`          | unique unit identifier, eg '987654' of prior tenant reference                               |
+| &nbsp;&nbsp;tenant                              | `hash`            |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;reference               | `string`          | uniquely identifies the NEW tenant reference                                                |
+| &nbsp;&nbsp;&nbsp;&nbsp;firstName               | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;surname                 | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;languageCode            | `string`          | de, fr, it or en; **must be lower case** (ISO 639-1)                                        |
+| &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode         | `string`          | ISO country code, eg 'CH' (ISO 3166-1 alpha-2)                                              |
+| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber             | `string`          | preferred number (based on person type) - might be null                                     |
+| &nbsp;&nbsp;&nbsp;&nbsp;email                   | `string`          | preferred email (based on person type) - might be null                                      |
+| &nbsp;&nbsp;&nbsp;&nbsp;fullName                | `string`          | built from the individual name parts, respecting the type of tenant (corporate or physical) |
+| &nbsp;&nbsp;&nbsp;&nbsp;type                    | `string`          | LEGAL (a company) or PHYSICAL (Physical person)                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth             | `string`          | ISO 8601 encoded date, eg '2019-05-30'                                                      |
+| &nbsp;&nbsp;&nbsp;&nbsp;allphoneNumbers         | `array of hashes` | a list of all available email addresses and type                                            |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;phoneNumber       | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type              | `string`          | one of: PRIVATE, PROFESSIONAL, MOBILE or OTHER                                              |
+| &nbsp;&nbsp;&nbsp;&nbsp;allEmails               | `array of hashes` | a list of all available email addresses and type                                            |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;emailAddress      | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type              | `string`          | one of: PRIVATE, PROFESSIONAL or OTHER                                                      |
+| &nbsp;&nbsp;&nbsp;&nbsp;postalAddress           | `hash`            | current address fields conformant to the eCH-0010 specs                                     |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;addressLine1      | `string`          | See eCH-0010 specs                                                                          |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;countryCode       | `string`          | ISO 3166-1 alpha-2 country code, eg CH                                                      |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;city              | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode           | `string`          |                                                                                             |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string`          | See eCH-0010 specs                                                                          |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street            | `string`          | Street name including number where appropriate                                              |
 
 #### Example
 

--- a/letting_context.md
+++ b/letting_context.md
@@ -8,11 +8,10 @@
 | [Letting.Tenancy.Created](#lettingtenancycreated)                                                   | :white_check_mark: | :x:                | A tenancy has been created; does not reliably signal a tenant move in. (1)     |
 | [Letting.Tenancy.Deleted](#lettingtenancydeleted)                                                   | :white_check_mark: | :x:                | A tenancy has been deleted; this means that the tenancy never became effective |
 | [Letting.Tenancy.MoveInConfirmed](#lettingtenancymoveinconfirmed)                                   | :x:                | :white_check_mark: | Confirms a tenant will move or has moved into a unit. (2)                      |
+| [Letting.Tenancy.MoveOutConfirmed](#lettingtenancymoveoutconfirmed)                                 | :x:                | :white_check_mark: | Confirms a tenant will move out or has moved out of a unit. (3)                |
 | [Letting.Tenancy.TenancyAgreementReferenceChanged](#lettingtenancytenancyagreementreferencechanged) | :white_check_mark: | :x:                | The reference of a tenancy agreement has changed                               |
 | [Letting.Tenancy.Updated](#lettingtenancyupdated)                                                   | :white_check_mark: | :x:                | Start and / or end date of a tenancy have been changed                         |
 | [Letting.TenancyAgreement.Activate](#lettingtenancyagreementactivate)                               | :white_check_mark: | :x:                | A tenancy agreement should be activated in GARAIO REM                          |
-| [Letting.Tenant.Merged](#lettingtenantmerged)                                                       | :white_check_mark: | :x:                | Notification when tenant has been merged into another record (all known new Tenant info is sent) |
-| [Letting.Tenant.Updated](#lettingtenantupdated)                                                     | :white_check_mark: | :x:                | Notification when tenant information has been updated/changed                  |
 | [Letting.TenancyAgreement.Create](#lettingtenancyagreementcreate)                                   | :white_check_mark: | :x:                | A tenancy agreement should be created in GARAIO REM                            |
 | [Letting.TenancyAgreement.Created](#lettingtenancyagreementcreated)                                 | :white_check_mark: | :x:                | The tenancy agreement has been activated.                                      |
 | [Letting.TenancyAgreement.Deactivated](#lettingtenancyagreementdeactivated)                         | :white_check_mark: | :x:                | The tenancy agreement has been deactivated.                                    |
@@ -26,6 +25,8 @@
 | [Letting.TenancyAgreement.Updated](#lettingtenancyagreementupdated)                                 | :white_check_mark: | :x:                | The activated tenancy agreement has some changes.                              |
 | [Letting.TenancyAgreementDetails.Update](#lettingtenancyagreementdetailsupdate)                     | :white_check_mark: | :x:                | Updates some details of a tenancy agreement.                                   |
 | [Letting.TenancyAgreementSecurityDepot.Update](#lettingtenancyagreementsecuritydepotupdate)         | :white_check_mark: | :x:                | Updates the reservation status of a unit.                                      |
+| [Letting.Tenant.Merged](#lettingtenantmerged)                                                       | :white_check_mark: | :x:                | Notification when tenant has been merged into another record (all known new Tenant info is sent) |
+| [Letting.Tenant.Updated](#lettingtenantupdated)                                                     | :white_check_mark: | :x:                | Notification when tenant information has been updated/changed                  |
 
 Notes
 
@@ -51,13 +52,12 @@ stateDiagram-v2
     Deactivated --> [*]
 ```
 
+### Letting.Tenancy.Created
+
 **NOTE:** New tenant fields have been added to be consistent with the GraphQL API, these include (fullName, type, dateOfBirth, type, allphoneNumbers, allEmails & postalAddress)
 Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
 
-<<<<<<< HEAD
 NOTE: We have discovered minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values for Legal and Physical persons. At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
-
-### Letting.Tenancy.Created
 
 | Field                                           | Type              | Content / Remarks                                                                           |
 | ----------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------- |
@@ -75,7 +75,6 @@ NOTE: We have discovered minor differences in the logic for sending the _preferr
 | &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode         | `string`          | ISO country code (ISO 3166-1 alpha-2), eg 'CH'                                              |
 | &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber             | `string`          | preferred number (based on person type) - might be null                                     |
 | &nbsp;&nbsp;&nbsp;&nbsp;email                   | `string`          | preferred email (based on person type) - might be null                                      |
-| new fields                                      |                   | Introduced in v1.21 (Q1 2024)                                                               |
 | &nbsp;&nbsp;&nbsp;&nbsp;fullName                | `string`          | built from the individual name parts, respecting the type of tenant (corporate or physical) |
 | &nbsp;&nbsp;&nbsp;&nbsp;type                    | `string`          | LEGAL (a company) or PHYSICAL (Physical person)                                             |
 | &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth             | `string`          | ISO 8601 encoded date, eg '2019-05-30'                                                      |
@@ -92,40 +91,6 @@ NOTE: We have discovered minor differences in the logic for sending the _preferr
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode           | `string`          |                                                                                             |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string`          | See eCH-0010 specs                                                                          |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street            | `string`          | Street name including number where appropriate                                              |
-=======
-| Field                                      | Type     | Content / Remarks                                         |
-| ------------------------------------------ | -------- | --------------------------------------------------------- |
-| eventType                                  | `string` | Letting.Tenancy.Created                                   |
-| data                                       | `hash`   |                                                           |
-| &nbsp;&nbsp;startDate                      | `string` | ISO 8601 encoded date, eg '2019-05-25'                    |
-| &nbsp;&nbsp;endDate                        | `string` | ISO 8601 encoded date, eg '2019-05-25'; might be null     |
-| &nbsp;&nbsp;tenancyAgreementReference      | `string` | unique tenancy agreement identifier, eg '1234.01.0001.01' |
-| &nbsp;&nbsp;unitReference                  | `string` | unique unit identifier, eg '234.01.0001'                  |
-| &nbsp;&nbsp;tenant                         | `hash`   |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;reference          | `string` | tenant reference; uniquely identifies a person            |
-| &nbsp;&nbsp;&nbsp;&nbsp;firstName          | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;surname            | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;languageCode       | `string` | de, fr, it or en; **must be lower case**                  |
-| &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode    | `string` | ISO country code, eg 'CH'                                 |
-| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber        | `string` | preferred number (based on person type) - might be null   |
-| &nbsp;&nbsp;&nbsp;&nbsp;email              | `string` | preferred email (based on person type) - might be null    |
-| &nbsp;&nbsp;&nbsp;&nbsp;fullName           | `string` | built from the individual name parts, respecting the type of tenant (corporate or physical) |
-| &nbsp;&nbsp;&nbsp;&nbsp;type               | `string` | LEGAL (a company) or PHYSICAL (Physical person)           |
-| &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth        | `string` | ISO 8601 encoded date, eg '2019-05-30'                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;allphoneNumbers    | `array of hashes` | a list of all available email addresses and type |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;phoneNumber  | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL, MOBILE or OTHER            |
-| &nbsp;&nbsp;&nbsp;&nbsp;allEmails          | `array of hashes` | a list of all available email addresses and type |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;emailAddress | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL or OTHER                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;postalAddress      | `hash`   | current address fields conformant to the eCH-0010 specs   |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;addressLine1 | `string` | See eCH-0010 specs                                        |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;countryCode  | `string` | ISO 3166-1 alpha-2 country code, eg CH                    |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;city         | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode      | `string` |                                                           |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string` | See eCH-0010 specs                                   |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street       | `string` | Street name including number where appropriate            |
->>>>>>> 052c4c6 (minor clarifications)
 
 #### Example
 

--- a/letting_context.md
+++ b/letting_context.md
@@ -51,8 +51,10 @@ stateDiagram-v2
     Deactivated --> [*]
 ```
 
-**NOTE:** New tenant fields have been added to be consistent with the GraphQL API. Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
+**NOTE:** New tenant fields have been added to be consistent with the GraphQL API, these include (fullName, type, dateOfBirth, type, allphoneNumbers, allEmails & postalAddress)
+Also note that the logic for the preferred phoneNumber and email fields has also changed to be consistent with the GraphQL API (the preferred value is now based on the person type).
 
+<<<<<<< HEAD
 NOTE: We have discovered minor differences in the logic for sending the _preferred_ `email` and `phoneNumber` in mbus messages, the priority is always the same for all persons, while GraphQL queries send different values for Legal and Physical persons. At the moment, we are not planning to change this behaviour without consulting our partners, in order to prevent unexpected side effects.
 
 ### Letting.Tenancy.Created
@@ -90,6 +92,40 @@ NOTE: We have discovered minor differences in the logic for sending the _preferr
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode           | `string`          |                                                                                             |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string`          | See eCH-0010 specs                                                                          |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street            | `string`          | Street name including number where appropriate                                              |
+=======
+| Field                                      | Type     | Content / Remarks                                         |
+| ------------------------------------------ | -------- | --------------------------------------------------------- |
+| eventType                                  | `string` | Letting.Tenancy.Created                                   |
+| data                                       | `hash`   |                                                           |
+| &nbsp;&nbsp;startDate                      | `string` | ISO 8601 encoded date, eg '2019-05-25'                    |
+| &nbsp;&nbsp;endDate                        | `string` | ISO 8601 encoded date, eg '2019-05-25'; might be null     |
+| &nbsp;&nbsp;tenancyAgreementReference      | `string` | unique tenancy agreement identifier, eg '1234.01.0001.01' |
+| &nbsp;&nbsp;unitReference                  | `string` | unique unit identifier, eg '234.01.0001'                  |
+| &nbsp;&nbsp;tenant                         | `hash`   |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;reference          | `string` | tenant reference; uniquely identifies a person            |
+| &nbsp;&nbsp;&nbsp;&nbsp;firstName          | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;surname            | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;languageCode       | `string` | de, fr, it or en; **must be lower case**                  |
+| &nbsp;&nbsp;&nbsp;&nbsp;nationalityCode    | `string` | ISO country code, eg 'CH'                                 |
+| &nbsp;&nbsp;&nbsp;&nbsp;phoneNumber        | `string` | preferred number (based on person type) - might be null   |
+| &nbsp;&nbsp;&nbsp;&nbsp;email              | `string` | preferred email (based on person type) - might be null    |
+| &nbsp;&nbsp;&nbsp;&nbsp;fullName           | `string` | built from the individual name parts, respecting the type of tenant (corporate or physical) |
+| &nbsp;&nbsp;&nbsp;&nbsp;type               | `string` | LEGAL (a company) or PHYSICAL (Physical person)           |
+| &nbsp;&nbsp;&nbsp;&nbsp;dateOfBirth        | `string` | ISO 8601 encoded date, eg '2019-05-30'                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;allphoneNumbers    | `array of hashes` | a list of all available email addresses and type |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;phoneNumber  | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL, MOBILE or OTHER            |
+| &nbsp;&nbsp;&nbsp;&nbsp;allEmails          | `array of hashes` | a list of all available email addresses and type |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;emailAddress | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type         | `string` | one of: PRIVATE, PROFESSIONAL or OTHER                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;postalAddress      | `hash`   | current address fields conformant to the eCH-0010 specs   |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;addressLine1 | `string` | See eCH-0010 specs                                        |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;countryCode  | `string` | ISO 3166-1 alpha-2 country code, eg CH                    |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;city         | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;zipCode      | `string` |                                                           |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;postOfficeBoxText | `string` | See eCH-0010 specs                                   |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;street       | `string` | Street name including number where appropriate            |
+>>>>>>> 052c4c6 (minor clarifications)
 
 #### Example
 


### PR DESCRIPTION
Discussion points: 
I made a few fields that may be unnecessary in some cases, but felt it was simpler for both the code and the API to keep things always the same, for example
1) **tenantReference**: (the reference that can used to identify the record) - tenant.reference may change if the tenant was merged into another record.
2) **tenant**: {} - it is slightly simpler (in my mind) to always use the same structure (and code) for Tenancy.Created, Tenant.Updated and Tenant.Merged.  In this way the data is always structured the same between GraphQL and Mbus.
3) Do we really need both: **Tenant.Updated** and **Tenant.Merged** - I feel like just Tenant.Updated is enough. The advantage is that Tenant.Merged helps call out the change in the reference and that all data will be sent, however, I think a simple one-line description can clarify these minor differences.
4) **email** and **phoneNumber** - is it a problem for existing customers of mbus to change the logic to be consistent with GraphQL
5) Adding **Address** - changes looks to be a bit more complex as it looks like there are several ways an address can change, is this indeed worthwhile? (we can update an Address on a Haus record ( _http://localhost:3000/haeuser/5087/haus_grunddaten/edit_ this address could also be associated with a person) on a person record it looks like we can create a new addresses _(http://localhost:3000/personen/588778/adressaenderung/new)_, but not change them.  What are all the Address change possibilities that would affect a 'Tenant'?

I look forward to ideas and refinements.