### PR TITLE
Remove optional backlink URL in minimal message examples

### DIFF
--- a/notification_context.md
+++ b/notification_context.md
@@ -35,8 +35,7 @@ Minimal Message without a masterdataReference
     "externalReference":"1234",
     "subject":"Invoice 12345678.pdf",
     "mimetype":"text/plain",
-    "message":"something went wrong",
-    "backlinkUrl":"https://instance.external_system.ch/case/3",
+    "message":"something went wrong"
   }
 }
 ```
@@ -49,8 +48,7 @@ Minimal Message with a masterdataReference
     "externalReference":"1234",
     "masterdataReference":"4712.01.0001",
     "mimetype":"text/plain",
-    "message":"something happened",
-    "backlinkUrl":"https://instance.external_system.ch/case/3",
+    "message":"something happened"
   }
 }
 ```

--- a/notification_context.md
+++ b/notification_context.md
@@ -27,7 +27,7 @@ data | hash |
 
 #### Example
 
-Minimal Message without a masterdataReference
+Minimal message without a `masterdataReference`:
 
 ```json
 {"eventType":"Notification.Message.Created",
@@ -40,7 +40,7 @@ Minimal Message without a masterdataReference
 }
 ```
 
-Minimal Message with a masterdataReference
+Minimal message with a `masterdataReference`:
 
 ```json
 {"eventType":"Notification.Message.Created",
@@ -63,7 +63,7 @@ Typical Message
     "sender":"max.muster@mailprovider.com",
     "mimetype":"text/plain",
     "message":"something happened",
-    "backlinkUrl":"https://instance.external_system.ch/case/3",
+    "backlinkUrl":"https://instance.external_system.ch/case/3"
   }
 }
 ```
@@ -83,7 +83,7 @@ data | hash |
 ```json
 {"eventType":"Notification.Case.Closed",
   "data":{
-    "externalReference":"1234",
+    "externalReference":"1234"
   }
 }
 ```


### PR DESCRIPTION
This is a follow-up to https://github.com/Garaio-REM/remcloud-message-bus-api/commit/66cf8b88766bdb3bfdcdce645c030a9ab90d85bd.