### PR TITLE
feat: provide payment information when creating and updating person

### DIFF
--- a/masterdata_context.md
+++ b/masterdata_context.md
@@ -928,6 +928,8 @@ GARAIO REM replies with a standard [Accepted](./result_messages.md#accepted-mess
 | &nbsp;&nbsp;&nbsp;&nbsp;`supplement`     | `string`                     | address supplement, e.g. Elektro-Fachgeschäft; **optional**                                                                                                                                                        |
 | &nbsp;&nbsp;&nbsp;&nbsp;`countryCode`    | `string`                     | ISO country code, eg `'CH'`. Defaults to 'CH'.                                                                                                                                                                     |
 | &nbsp;&nbsp;`contactData`                | `hash`                       | [ContactData](types/contact_data.md) of this person.                                                                                                                                                               |
+| &nbsp;&nbsp;`paymentDetails`             | `array`                      | [PaymentDetails](types/payment_details.md) of this person.                                                                                                                                                         |
+
 
 #### example
 
@@ -948,7 +950,14 @@ GARAIO REM replies with a standard [Accepted](./result_messages.md#accepted-mess
       "zipCode":"3007",
       "street":"Gartenstrasse 1/3",
       "countryCode":"CH"
-    }
+    },
+    "paymentDetails": [
+      {
+        "iban":"DE19500105176829385733",
+        "bic":"WELLDEVBD",
+        "defaultPaymentDetail":true
+      }
+    ]
   }
 }
 ```
@@ -1049,6 +1058,7 @@ Field | Type | Content / Remarks
 &nbsp;&nbsp;&nbsp;&nbsp;`validFrom` | `string` | optional ISO 8601 encoded date; pass a future date to create or update an address that becomes valid in the future
 &nbsp;&nbsp;&nbsp;&nbsp;`deleted` | `boolean` | pass `true` to delete the address
 &nbsp;&nbsp;`contactData`| `hash` | [ContactData](types/contact_data.md) of this person.
+&nbsp;&nbsp;`paymentDetails`| `array`| [PaymentDetails](types/payment_details.md) of this person.
 
 #### examples
 
@@ -1071,7 +1081,14 @@ Field | Type | Content / Remarks
       "street":"Gartenstrasse 1/3",
       "countryCode":"CH",
       "postbox":"123456"
-    }
+    },
+    "paymentDetails": [
+      {
+        "iban":"DE19500105176829385733",
+        "bic":"WELLDEVBD",
+        "defaultPaymentDetail":true
+      }
+    ]
   }
 }
 ```

--- a/types/payment_details.md
+++ b/types/payment_details.md
@@ -1,0 +1,22 @@
+# PaymentsDetails
+
+Payment details of a person. This is a Array of hash structured as follows.
+
+Field | Type | Content / Remarks
+---|---|---
+&nbsp;&nbsp;`paymentDetails` | `array` | list of new payment details
+&nbsp;&nbsp;&nbsp;&nbsp;`iban` | `string` | iban; **required**
+&nbsp;&nbsp;&nbsp;&nbsp;`ibanName` | `string` | iban name, e.g. name of the bank
+&nbsp;&nbsp;&nbsp;&nbsp;`bic` | `string` | bic
+&nbsp;&nbsp;&nbsp;&nbsp;`locked` | `boolean` | should the payment detail be locked
+&nbsp;&nbsp;&nbsp;&nbsp;`lockReason` | `string` | why should the payment detail be locked? required if you set `locked` to `true`
+&nbsp;&nbsp;&nbsp;&nbsp;`defaultPaymentDetail` | `boolean` | should this payment detail be the default? Set it to `true` if the payment detail should become the default. Do not send `false` since that makes no sense, we will ignore it. If you send `true` for more than one payment detail, the last one wins
+
+## Merging strategy
+
+When updating `PaymentsDetails`, fields are merged as follows:
+
+* do not send the attribute if you do not want to create current data of this type
+* send an empty array (`[]`) to delete all current data of this type
+* send an array of valid data to fully replace the current data of this type
+* payment details that exist but are not contained in the paymentDetails will be locked


### PR DESCRIPTION
When creating and updating person we can now add/update paymentDetails.