### PR TITLE
feat: REM-31694 document new Invoicing.Order fields:

### DIFF
--- a/invoicing_context.md
+++ b/invoicing_context.md
@@ -46,6 +46,8 @@ This message goes from the order provider to GARAIO REM. Set the recipient prope
 | &nbsp;&nbsp;`languageCode`                                 | `string`  | `de`, `fr`, `it` or `en`; will be used to send error reasons using the desired language; **must be lower case**                                                                |
 | &nbsp;&nbsp;`backlinkUrl`                                  | `string`  | optional url to navigate to the order on the sending system; **must be a complete url that the local browser can resolve (including protocol), e.g. <https://www.google.com>** |
 | &nbsp;&nbsp;`clerkUsername`                                | `string`  | Username of clerk (Sachbearbeiter) to assign.                                                                                                                                  |
+| &nbsp;&nbsp;`orderCreatorUser`                             | `string`  | Username of the user who created the order (optional)                                                                                                                          |
+| &nbsp;&nbsp;`totalGrossAmount`                             | `decimal` | Total gross amount of the order - including VAT (optional)                                                                                                                     |
 | &nbsp;&nbsp;`orderItems`                                   | `array`   | List of order items; may be empty                                                                                                                                              |
 | &nbsp;&nbsp;&nbsp;&nbsp;`itemNumber`                       | `integer` | invoice item number to preserve order; **required**                                                                                                                            |
 | &nbsp;&nbsp;&nbsp;&nbsp;`accountNumber`                    | `string`  | accounting account number, eg "10122"; must be valid for the accounting that belongs to the `masterdataReference`  **required**                                                |
@@ -81,6 +83,8 @@ This message goes from the order provider to GARAIO REM. Set the recipient prope
     "languageCode":"fr",
     "backlinkUrl":"https://instance.external_system.ch/order/3",
     "clerkUsername": "clerk",
+    "orderCreatorUser": "user123",
+    "totalGrossAmount": 1500.00,
     "orderItems":[
       {
         "lineNumber":1,
@@ -98,6 +102,7 @@ This message goes from the order provider to GARAIO REM. Set the recipient prope
 }
 ```
 
+
 ### Invoicing.Order.WasCreated
 
 This is an event sent by GARAIO REM.
@@ -110,6 +115,8 @@ This is an event sent by GARAIO REM.
 | &nbsp;&nbsp;`externalReference`               | `string`  | external identifier from the order provider                                      |
 | &nbsp;&nbsp;`accountingReference`             | `string`  | reference of the accounting                                                      |
 | &nbsp;&nbsp;`masterdataReference`             | `string`  | reference of a property / building / unit                                        |
+| &nbsp;&nbsp;`orderCreatorUser`                | `string`  | Username of the user who created the order                                       |
+| &nbsp;&nbsp;`totalGrossAmount`                | `decimal` | Total gross amount of the order - including VAT                                  |
 | &nbsp;&nbsp;`orderItems`                      | `array`   | order items                                                                      |
 | &nbsp;&nbsp;&nbsp;&nbsp;`accountNumber`       | `string`  | accounting account number, prefixed by the accounting reference, eg "6056.10122" |
 | &nbsp;&nbsp;&nbsp;&nbsp;`costCenterNumber`    | `string`  | cost center number                                                               |
@@ -126,6 +133,8 @@ This is an event sent by GARAIO REM.
     "reference": 123,
     "accountingReference": "1",
     "masterdataReference": "10001",
+    "orderCreatorUser": "user123",
+    "totalGrossAmount": 1500.00,
     "orderItems": [
       {
         "accountNumber": "641201",
@@ -221,6 +230,8 @@ This message completely replaces an existing order in GARAIO REM; if you pass, f
 | &nbsp;&nbsp;`languageCode`                                 | `string`     | `de`, `fr`, `it` or `en`; determines error reasons language; **must be lower case**                                                                                            |
 | &nbsp;&nbsp;`backlinkUrl`                                  | `string`     | optional url to navigate to the order on the sending system; **must be a complete url that the local browser can resolve (including protocol), e.g. <https://www.google.com>** |
 | &nbsp;&nbsp;`clerkUsername`                                | `string`     | Username of clerk (Sachbearbeiter) to assign.                                                                                                                                  |
+| &nbsp;&nbsp;`orderCreatorUser`                             | `string`     | Username of the user who created the order - optional (2)                                                                                                                      |
+| &nbsp;&nbsp;`totalGrossAmount`                             | `decimal`    | Total gross amount of the order - includeing VAT - optional (2)                                                                                                                |
 | &nbsp;&nbsp;`completedAt`                                  | `date\|null` | The day the ordered work has been completed. If null, this means the work has not been completed yet.                                                                          |
 | &nbsp;&nbsp;`done`                                         | `boolean`    | mark the order as done (erledigt)                                                                                                                                              |
 | &nbsp;&nbsp;`orderItems`                                   | `array`      | List of order items; may be empty; orderItems that exists in the order but are not passed here will be deleted                                                                 |
@@ -238,6 +249,7 @@ This message completely replaces an existing order in GARAIO REM; if you pass, f
 **Notes:**
 
 * (1) You have to provide either `reference` or `externalReference`. The reference you provide must be a reference that has previously been published in a `Invoicing.Order.Created` message.
+* (2) The field will be updated if the keys: `orderCreatorUser` and/or `totalGrossAmount` are included - if not included in the message any pre-esisting value will remain unchanged.
 
 #### Example
 
@@ -258,6 +270,8 @@ This message completely replaces an existing order in GARAIO REM; if you pass, f
     "deliveryAddress":"Garaio AG\\nLaupenstrasse 45\\n3001 Bern",
     "languageCode":"fr",
     "clerkUsername":"Testuser_5",
+    "orderCreatorUser": "user123",
+    "totalGrossAmount": 1500.00,
     "completedAt": "2023-01-01",
     "orderItems":[
       {
@@ -300,6 +314,8 @@ This is an event sent by GARAIO REM.
 | &nbsp;&nbsp;`externalReference`               | `string`  | external identifier from the order provider                                      |
 | &nbsp;&nbsp;`accountingReference`             | `string`  | reference of the accounting                                                      |
 | &nbsp;&nbsp;`masterdataReference`             | `string`  | reference of a property / building / unit                                        |
+| &nbsp;&nbsp;`orderCreatorUser`                | `string`  | Username of the user who created the order.                                      |
+| &nbsp;&nbsp;`totalGrossAmount`                | `decimal` | Total gross amount of the order - including VAT.                                 |
 | &nbsp;&nbsp;`orderItems`                      | `array`   | order items                                                                      |
 | &nbsp;&nbsp;&nbsp;&nbsp;`accountNumber`       | `string`  | accounting account number, prefixed by the accounting reference, eg "6056.10122" |
 | &nbsp;&nbsp;&nbsp;&nbsp;`costCenterNumber`    | `string`  | cost center number                                                               |
@@ -316,6 +332,8 @@ This is an event sent by GARAIO REM.
     "reference": 123,
     "accountingReference": "1",
     "masterdataReference": "10001",
+    "orderCreatorUser": "user123",
+    "totalGrossAmount": 1500.00,
     "orderItems": [
       {
         "accountNumber": "641201",


### PR DESCRIPTION
orderCreatorUser (optional) and totalGrossAmount (optional)

Adds documentation for the new fields `orderCreatorUser` and `totalGrossAmount`

to the messages:
- `Invoicing.Order.Created`,
- `Invoicing.Order.Updated`,
- `Invoicing.Order.WasCreated`, and `
- `Invoicing.Order.WasUpdated`.

Includes a note explaining update behavior